### PR TITLE
Addition of NCCS LinkedIn URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,3 +57,4 @@ is_government: false
 facebook-pixel: ""
 google_analytics: ""
 linkedin-insights: ""
+google_analytics_ga4: ""

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -4,4 +4,4 @@ privacy_policy: /privacy-statement/
 social_media:
   facebook: https://www.facebook.com/ClimateChangeSG
   instagram: https://www.instagram.com/climatechangesg/
-
+  linkedin: https://www.linkedin.com/company/nccs-sg


### PR DESCRIPTION
Added the NCCS LinkedIn URL in the Site Settings. The LinkedIn icon is displayed at the bottom right of the website.